### PR TITLE
copy all urls to clipboard when clicking the browserAction

### DIFF
--- a/background.js
+++ b/background.js
@@ -340,7 +340,7 @@ function clearNotifs(all) {
 	}
 }
 
-browser.browserAction.onClicked.addListener(() => refresh());
+browser.browserAction.onClicked.addListener(() => copyURL(Object.keys(urlList)));
 
 browser.menus.onClicked.addListener((info, tab) => {
 	if (info.menuItemId === "m3u8linkPause") {


### PR DESCRIPTION
Dear @rowrawer,

First of all thank you for creating this web extension and releasing it as a free software.

After installing it and testing it with a certain website I know has a m3u file youtube-dl can work with, I was disappointed that it did detect urls according to the notifications but I couldn't find any URL within the extension's UI - `browserAction.onClicked()` seemed only to be removing the number of URLs detected.

I was surprised to find out after quiet some time of `console.log` debugging that clicking the `browserAction` clears all the urls stream-detector has found. Hence I think this change, without _too_ much [refactoring](https://github.com/rowrawer/stream-detector/blob/ead8cbd0d1aa0efe8bf8e9504aacae79511d909e/background.js#L100) would slightly improve mine and potentiality other's experience.

Regards.