### PR TITLE
remove clipboard permission

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -18,7 +18,6 @@
 		"*://*/*.vtt",
 		"*://*/*.vtt?*",
 		"notifications",
-		"clipboardWrite",
 		"storage",
 		"activeTab"
 	],
@@ -60,3 +59,4 @@
 		]
 	}
 }
+


### PR DESCRIPTION
* OS: 5.7.10-arch1-1
* Firefox Version: 79.0 (using web-ext)

`clipboardWrite` should only be necessary if the Clipboard API is outside of a user-initiated gesture. This is the behavior in [Firefox (MDN link)][1] and also part of the [W3C spec][2]. I also verified this behavior locally.

[1]:https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/writeText#Browser_compatibility
[2]:https://w3c.github.io/clipboard-apis/#h-clipboard-write-permission