### PR TITLE
Fix clipboard fallback.

### DIFF
--- a/popup/popup.js
+++ b/popup/popup.js
@@ -217,7 +217,7 @@ function copyURL(info) {
 			list.filenames.push(`${filename}.${ext}`);
 			list.methodIncomp = methodIncomp;
 		}
-		if (navigator.clipboard.writeText) {
+		if (navigator.clipboard && navigator.clipboard.writeText) {
 			navigator.clipboard.writeText(list.urls.join("\n")).then(
 				() => {
 					if (options.notifPref !== true) {


### PR DESCRIPTION
While trying to use this extension in Waterfox, I was getting the error "navigator.clipboard is undefined". After looking at the code, I discovered there was already a fallback check but it was not fully working. Adding a check if navigator.clipboard exists before trying writeText fixes this issue.