### PR TITLE
Check content types alongside URL patterns

### DIFF
--- a/background.js
+++ b/background.js
@@ -130,7 +130,7 @@ function deleteURL(message) {
 
 function filterContentType(requestDetails) {
 	let header = requestDetails.responseHeaders.find(
-        	(h) => h.name === "content-type"
+		(h) => h.name.toLowerCase() === "content-type"
 	);
 	if (header) {
 		const value = header.value.toLowerCase();

--- a/background.js
+++ b/background.js
@@ -24,6 +24,12 @@ const listenerFilter = {
 	]
 };
 
+const typeListenerFilter = {
+	urls: ["<all_urls>"]
+};
+
+const contentTypes = ["application/x-mpegurl", "application/vnd.apple.mpegurl"];
+
 const _ = browser.i18n.getMessage;
 
 let urlStorage = [];
@@ -122,6 +128,18 @@ function deleteURL(message) {
 	});
 }
 
+function filterContentType(requestDetails) {
+	let header = requestDetails.responseHeaders.find(
+        	(h) => h.name === "content-type"
+	);
+	if (header) {
+		const value = header.value.toLowerCase();
+		if (contentTypes.some((ct) => ct === value)) {
+			addURL(requestDetails);
+		}
+	}
+}
+
 function setup() {
 	// clear everything and/or set up
 	browser.browserAction.setBadgeText({ text: "" });
@@ -137,6 +155,11 @@ function setup() {
 					addURL,
 					listenerFilter,
 					["requestHeaders"]
+				);
+				browser.webRequest.onHeadersReceived.addListener(
+					filterContentType,
+					typeListenerFilter,
+					["responseHeaders"]
 				);
 				if (options.urlStorage && options.urlStorage.length > 0) {
 					// restore urls on startup

--- a/manifest.json
+++ b/manifest.json
@@ -5,6 +5,7 @@
 	"default_locale": "en",
 	"version": "2.3.3",
 	"permissions": [
+		"<all_urls>",
 		"*://*/*.m3u8",
 		"*://*/*.m3u8?*",
 		"*://*/*.mpd",


### PR DESCRIPTION
Currently the extension misses a few streams because the URLs which return the segments don't end in any of the patterns in the filter.

A few of the streams which are missed do have the HTTP content type header set in a way we can recognize as a stream.

This PR adds an additional listener and filter to discover some of these streams.

A possible downside is that the `<all_urls>` permission is now required, but I think that's a minor inconvenience for the extra functionality. 