### PR TITLE
use clipboard api for copying url

### DIFF
--- a/content/popup.js
+++ b/content/popup.js
@@ -325,8 +325,7 @@ const copyURL = (info) => {
 		document.body.appendChild(copyText);
 		copyText.value = list.urls.join("\n");
 		try {
-			copyText.select();
-			document.execCommand("copy");
+			navigator.clipboard.writeText(copyText.value);
 			document.body.removeChild(copyText);
 			if (options.notifPref !== true) {
 				chrome.notifications.create("copy", {


### PR DESCRIPTION
as the old method is broken on wayland.
api: https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/writeText