### PR TITLE
fix: Check for header and value existance

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -80,8 +80,8 @@ const urlFilter = (requestDetails) => {
 		// go through the extensions and see if the url contains any
 		e =
 			customExtPref === true &&
-			customSupported &&
-			customSupported.ext?.some((fe) => url.includes("." + fe));
+			customSupported.ext?.some((fe) => url.includes("." + fe))
+			customSupported;
 		if (!e)
 			e = supported.find((f) => f.ext.some((fe) => url.includes("." + fe)));
 	} else if (requestDetails.responseHeaders) {
@@ -92,8 +92,8 @@ const urlFilter = (requestDetails) => {
 			// go through content types and see if the header matches
 			e =
 				customCtPref === true &&
-				customSupported &&
-				customSupported.ct?.includes(header.value.toLowerCase());
+				customSupported.ct?.includes(header.value.toLowerCase()) &&
+				customSupported;
 			if (!e)
 				e = supported.find((f) => f.ct.includes(header.value.toLowerCase()));
 		}

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -80,22 +80,23 @@ const urlFilter = (requestDetails) => {
 		// go through the extensions and see if the url contains any
 		e =
 			customExtPref === true &&
-			customSupported.ext?.some((fe) => url.includes("." + fe)) &&
-			customSupported;
+			customSupported &&
+			customSupported.ext?.some((fe) => url.includes("." + fe));
 		if (!e)
 			e = supported.find((f) => f.ext.some((fe) => url.includes("." + fe)));
 	} else if (requestDetails.responseHeaders) {
 		const header = requestDetails.responseHeaders.find(
 			(h) => h.name.toLowerCase() === "content-type"
 		);
-		if (header)
+		if (header && header.value) {
 			// go through content types and see if the header matches
 			e =
 				customCtPref === true &&
-				customSupported.ct?.includes(header.value.toLowerCase()) &&
-				customSupported;
-		if (!e)
-			e = supported.find((f) => f.ct.includes(header.value.toLowerCase()));
+				customSupported &&
+				customSupported.ct?.includes(header.value.toLowerCase());
+			if (!e)
+				e = supported.find((f) => f.ct.includes(header.value.toLowerCase()));
+		}
 	}
 
 	if (

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -80,7 +80,7 @@ const urlFilter = (requestDetails) => {
 		// go through the extensions and see if the url contains any
 		e =
 			customExtPref === true &&
-			customSupported.ext?.some((fe) => url.includes("." + fe))
+			customSupported.ext?.some((fe) => url.includes("." + fe)) &&
 			customSupported;
 		if (!e)
 			e = supported.find((f) => f.ext.some((fe) => url.includes("." + fe)));


### PR DESCRIPTION
Edited: Remove additional changes

Issue:
Using the extension I got an error `Cannot read properties of undefined (reading 'value')` and it is because the second evaluation for `e` happens regardless of the existence of `header`.

```
		if (header)
			// go through content types and see if the header matches
			e =
				customCtPref === true &&
				customSupported.ct?.includes(header.value.toLowerCase()) &&
				customSupported;
               // here will run regardless of the existence of header
		if (!e) 
			e = supported.find((f) => f.ct.includes(header.value.toLowerCase()));
```

Proposed fix:
Evaluate `header` and `value` first as both expressions relay on them.
```
		if (header && header.value) {
			// go through content types and see if the header matches
			e =
				customCtPref === true &&
				customSupported.ct?.includes(header.value.toLowerCase()) &&
                                customSupported;
			if (!e)
				e = supported.find((f) => f.ct.includes(header.value.toLowerCase()));
		}
```

**Disregard this part**
Additional changes:
I noticed that `customSupported` is evaluated at the end in two expressions. If `customSupported.ct` and `customSupported.ext` are present, `customSupported` will evaluate to true for sure but probably the intention is to identify it first before accessing the properties, so I moved the evaluation first in line 83 and 95.
