### PR TITLE
Performance issues adding many URLs at once

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "The Stream Detector",
+	"name": "the-stream-detector",
 	"author": {
 		"name": "rowrawer",
 		"email": "rowrawer@gmail.com",

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -10,6 +10,8 @@ let urlStorage = [];
 let urlStorageRestore = [];
 let badgeText = 0;
 let queue = [];
+let requestTimeoutId = -1;
+let allRequestDetails = [];
 
 let subtitlePref;
 let filePref;
@@ -228,19 +230,26 @@ const addURL = async (requestDetails) => {
 			text: badgeText.toString()
 		});
 
-		await setStorage({ urlStorage });
+		// debounce lots of requests in a short period of time
+		clearTimeout(requestTimeoutId);
+		allRequestDetails.push(requestDetails);
 
-		chrome.runtime.sendMessage({ urlStorage: true }); // update popup if opened
-		queue = queue.filter((q) => q !== requestDetails.requestId); // processing finished - remove from queue
+		requestTimeoutId = setTimeout(async () => {
+			await setStorage({ urlStorage });
+			chrome.runtime.sendMessage({ urlStorage: true }); // update popup if opened
+			allRequestDetails.map(d => d.requestId)
+								  .forEach(id => queue.splice(queue.indexOf(id, 1))); // remove all batched requests from queue
 
-		if (!notifDetectPref && !notifPref)
-			chrome.notifications.create("add", {
-				// id = only one notification of this type appears at a time
-				type: "basic",
-				iconUrl: "img/icon-dark-96.png",
-				title: _("notifTitle"),
-				message: _("notifText", requestDetails.type) + filename
-			});
+			if(!notifDetectPref && !notifPref) {
+				chrome.notifications.create("add", {
+					// id = only one notification of this type appears at a time
+					type: "basic",
+					iconUrl: "img/icon-dark-96.png",
+					title: _("notifTitle"),
+					message: _("notifText", requestDetails.type) + filename
+				});
+			}
+		}, 100)
 	}
 };
 

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -238,7 +238,7 @@ const addURL = async (requestDetails) => {
 			await setStorage({ urlStorage });
 			chrome.runtime.sendMessage({ urlStorage: true }); // update popup if opened
 			allRequestDetails.map(d => d.requestId)
-								  .forEach(id => queue.splice(queue.indexOf(id, 1))); // remove all batched requests from queue
+				.forEach(id => queue.splice(queue.indexOf(id, 1))); // remove all batched requests from queue
 
 			if(!notifDetectPref && !notifPref) {
 				chrome.notifications.create("add", {


### PR DESCRIPTION
I was trying to replicate an intermittent performance issue on the initial load of the popup and I found one possible cause when detecting many URLs in a short period of time. It's possible that while scrolling through a media-heavy page the `urlStorage` is serialized to the local storage synchronously and blocks the reading of the local storage in the rendering in `popup.js`.

I was profiling the performance starting with the `DOMContentLoaded` in `popup.js` and I noticed that when adding many URLs at once the UI would freeze for some time. To test I ran a local http server (darkhttpd), opened to http://localhost:8080 in the browser, then in dev tools ran ```for(let i = 0; i < 1000; i++) fetch(`file${i}.m3u8`)```

While profiling I saw that the promise returned from the `getStorage` call took 8-12 seconds to resolve and blocked the rendering of the popup. I had a single core at 100% usage while this was happening. The effect was noticeable even with 100 URLs. 

Anyway, I debounced the call every 100ms to `setStorage` when adding a URL so it's only fired for the final URL with the only side-effect being the notification type is emitted as the type of the final URL. The performance is vastly different, 1500 URLs previously loaded for >30s now load instantly after the popup appears. I'm not sure if it's related to #31 and #80 but this may help? The state of the popup looked exactly like the image in #31 until the `setStorage` calls are finished. Tested on latest Firefox dev and Firefox 91.9.1esr.

Also I renamed the `name` field in package.json because I was getting an error `npm ERR! Invalid name: "The Stream Detector"
` when running `npm build` or `npm start` and the docs say that you [can't use spaces](https://nodejs.dev/learn/the-package-json-guide#name). Replacing with dashes fixed the issue.